### PR TITLE
Fix invalid heredoc terminator in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ name "something or other"
 <Section>
    section-name  whatever
 </Section>
-EIEO
+EIEIO
 
 say $config.get-item('name'); # "something or other"
 say $config.get-item('Section', 'section-name'); # "whatever"


### PR DESCRIPTION
This fixes the syntax highlighting on GitHub.